### PR TITLE
Make jwt.io Message Less Alarming

### DIFF
--- a/bin/jwt.js
+++ b/bin/jwt.js
@@ -28,6 +28,7 @@ if (token.decoded === null) {
     return;
 }
 
+console.log(colors.yellow('\nTo verify on jwt.io:'));
 console.log(
     '\n' +
     colors.red('http://jwt.io/#id_token=') +


### PR DESCRIPTION
I actually had to come look at the source to verify my tokens weren’t being sent to a public service. If you feel that the message is useful in general, this change will hopefully reduce skipped heartbeats.
