### PR TITLE
Only show timestamps that are in the payload

### DIFF
--- a/bin/jwt.js
+++ b/bin/jwt.js
@@ -41,7 +41,9 @@ function processToken(token) {
     console.log(colors.yellow(json.plain(token.decoded.payload)));
 
     ['iat', 'nbf', 'exp'].forEach(field => {
-        console.log(colors.yellow(`   ${field}: `) + niceDate(token.decoded.payload[field]));
+        if (token.decoded.payload[field] !== undefined) {
+            console.log(colors.yellow(`   ${field}: `) + niceDate(token.decoded.payload[field]));
+        }
     });
 
     console.log(colors.magenta('\n✻ Signature ' + token.decoded.signature));

--- a/bin/jwt.js
+++ b/bin/jwt.js
@@ -5,8 +5,13 @@ var json = require('format-json');
 var jwt = require('jsonwebtoken');
 
 function niceDate(unixTimestamp) {
-    var date = new Date(unixTimestamp * 1000);
-    return colors.yellow(unixTimestamp) + " " + date.toLocaleString();
+    var dateString;
+    if (typeof unixTimestamp === 'number' && !isNaN(unixTimestamp)) {
+        dateString = new Date(unixTimestamp * 1000).toLocaleString();
+    } else {
+        dateString = "Invalid Date";
+    }
+    return colors.yellow(unixTimestamp) + " " + dateString;
 }
 
 function processToken(token) {

--- a/bin/jwt.js
+++ b/bin/jwt.js
@@ -40,9 +40,9 @@ function processToken(token) {
     console.log(colors.yellow('\n✻ Payload'));
     console.log(colors.yellow(json.plain(token.decoded.payload)));
 
-    console.log(colors.yellow('   iat: ') + niceDate(token.decoded.payload.iat));
-    console.log(colors.yellow('   nbf: ') + niceDate(token.decoded.payload.nbf));
-    console.log(colors.yellow('   exp: ') + niceDate(token.decoded.payload.exp));
+    ['iat', 'nbf', 'exp'].forEach(field => {
+        console.log(colors.yellow(`   ${field}: `) + niceDate(token.decoded.payload[field]));
+    });
 
     console.log(colors.magenta('\n✻ Signature ' + token.decoded.signature));
 }


### PR DESCRIPTION
All of iat, nbf and exp are defined as optional in RFC 7519, so I think it makes sense to handle tokens where they are absent gracefully.

For example, for a token with an issued-at but no expiration or not-before, the Payload section before would read:

```
✻ Payload
{
  "sub": "1234567890",
  "name": "John Doe",
  "iat": 1516239022
}
   iat: 1516239022 2018-1-17 20:30:22
   nbf: undefined Invalid Date
   exp: undefined Invalid Date
```

And afterwards the `nbf` and `exp` feels that are absent in the payload are omitted in the output:

```
✻ Payload
{
  "sub": "1234567890",
  "name": "John Doe",
  "iat": 1516239022
}
   iat: 1516239022 2018-1-17 20:30:22
```

This also explicitly outputs 'Invalid Date' if the value found is not numeric. RFC 7519 defines    NumericDate as a "JSON numeric value", so I think it's better to describe non-numeric values as invalid than to coerce a string containing a number to format a real timestamp.