### PR TITLE
Bump colors version

### DIFF
--- a/bin/jwt.js
+++ b/bin/jwt.js
@@ -1,6 +1,6 @@
 #! /usr/bin/env node
 
-var colors = require('colors');
+var colors = require('colors/safe');
 var json = require('format-json');
 var jwt = require('jsonwebtoken');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "colors": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
-      "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.2.tgz",
+      "integrity": "sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ=="
     },
     "ecdsa-sig-formatter": {
       "version": "1.0.10",


### PR DESCRIPTION
I ran into this while trying odd values for timestamp fields for pull #7. Setting exp/iat/nbf to `null` would cause the rendering to fail part-way through:

```
$ bin/jwt.js eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJuYmYiOm51bGx9.qAZxzP1uTfGp_rT5486WsK86_xZYPNTfDeoWPnZgkZY

http://jwt.io/#id_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJuYmYiOm51bGx9.qAZxzP1uTfGp_rT5486WsK86_xZYPNTfDeoWPnZgkZY

✻ Header
{
  "alg": "HS256",
  "typ": "JWT"
}

✻ Payload
{
  "sub": "1234567890",
  "name": "John Doe",
  "iat": 1516239022,
  "nbf": null
}
   iat: 1516239022 2018-1-17 20:30:22
/.../jwt-cli/node_modules/colors/lib/colors.js:108
    if (arg !== undefined && arg.constructor === String) {
                                 ^

TypeError: Cannot read property 'constructor' of null
...
```

With the change the output is odd, but at least it completes successfully:

```
...
✻ Payload
{
  "sub": "1234567890",
  "name": "John Doe",
  "iat": 1516239022,
  "nbf": null
}
   iat: 1516239022 2018-1-17 20:30:22
   nbf: null 1969-12-31 19:00:00
   exp: undefined Invalid Date
...
```

I'll fix the oddness by updating pull #7.