### PR TITLE
Added claim full names for dates

### DIFF
--- a/bin/jwt.js
+++ b/bin/jwt.js
@@ -47,11 +47,12 @@ function processToken(token) {
     console.log(colors.yellow('\n✻ Payload'));
     console.log(colors.yellow(json.plain(token.decoded.payload)));
 
-    ['iat', 'nbf', 'exp'].forEach(field => {
+    const dates = {'iat': 'Issued At', 'nbf': 'Not Before', 'exp': 'Expiration Time'}
+    for (const [field, name] of Object.entries(dates)) {
         if (token.decoded.payload.hasOwnProperty(field)) {
-            console.log(colors.yellow(`   ${field}: `) + niceDate(token.decoded.payload[field]));
+            console.log(colors.yellow(`   ${name}: `) + niceDate(token.decoded.payload[field]));
         }
-    });
+    }
 
     console.log(colors.magenta('\n✻ Signature ' + token.decoded.signature));
 }


### PR DESCRIPTION
Made it easier to understand what the dates mean when checking a token

```
# jwt eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOlwvXC9leGFtcGxlLm9yZyIsImF1ZCI6Imh0dHA6XC9cL2V4YW1wbGUuY29tIiwiaWF0IjoxMzU2OTk5NTI0LCJuYmYiOjEzNTcwMDAwMDAsImV4cCI6MTQwNzAxOTYyOSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczpcL1wvZXhhbXBsZS5jb21cL3JlZ2lzdGVyIiwidGVzdC10eXBlIjoiZm9vIn0.UGLFIRACaHpGGIDEEv-4IIdLfCGXT62X1vYx7keNMyc

To verify on jwt.io:

https://jwt.io/#id_token=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwOlwvXC9leGFtcGxlLm9yZyIsImF1ZCI6Imh0dHA6XC9cL2V4YW1wbGUuY29tIiwiaWF0IjoxMzU2OTk5NTI0LCJuYmYiOjEzNTcwMDAwMDAsImV4cCI6MTQwNzAxOTYyOSwianRpIjoiaWQxMjM0NTYiLCJ0eXAiOiJodHRwczpcL1wvZXhhbXBsZS5jb21cL3JlZ2lzdGVyIiwidGVzdC10eXBlIjoiZm9vIn0.UGLFIRACaHpGGIDEEv-4IIdLfCGXT62X1vYx7keNMyc

✻ Header
{
  "typ": "JWT",
  "alg": "HS256"
}

✻ Payload
{
  "iss": "http://example.org",
  "aud": "http://example.com",
  "iat": 1356999524,
  "nbf": 1357000000,
  "exp": 1407019629,
  "jti": "id123456",
  "typ": "https://example.com/register",
  "test-type": "foo"
}
   Issued At: 1356999524 1/1/2013, 12:18:44 AM
   Not Before: 1357000000 1/1/2013, 12:26:40 AM
   Expiration Time: 1407019629 8/2/2014, 11:47:09 PM

✻ Signature UGLFIRACaHpGGIDEEv-4IIdLfCGXT62X1vYx7keNMyc
```