### PR TITLE
Adding verification functionality

### DIFF
--- a/bin/jwt.js
+++ b/bin/jwt.js
@@ -61,9 +61,9 @@ function processToken(token) {
 function verifyToken(token, secret) {
     try {
         jwt.verify(token.string, secret);
-        console.log(colors.green('\nSignature Verified!'));
+        console.log(colors.green('\n✻ Signature Verified!'));
     } catch(err) {
-        console.log(colors.red('\nInvalid Signature!'));
+        console.log(colors.red('\n✻ Invalid Signature!'));
     }
 }
 

--- a/bin/jwt.js
+++ b/bin/jwt.js
@@ -29,7 +29,7 @@ function processToken(token) {
 
     if (token.decoded === null) {
         console.log('\n😾  token no good');
-        return;
+        return false;
     }
 
     console.log(colors.yellow('\nTo verify on jwt.io:'));
@@ -55,13 +55,28 @@ function processToken(token) {
     }
 
     console.log(colors.magenta('\n✻ Signature ' + token.decoded.signature));
+    return true;
 }
+
+function verifyToken(token, secret) {
+    try {
+        jwt.verify(token.string, secret);
+        console.log(colors.green('\nSignature Verified!'));
+    } catch(err) {
+        console.log(colors.red('\nInvalid Signature!'));
+    }
+}
+
 
 var token = {};
 
 if (process.stdin.isTTY) {
     token['string'] = process.argv[2];
-    processToken(token);
+    let isValid = processToken(token);
+    if (process.argv.length > 3 && isValid) {
+        let secret = process.argv[3];
+        verifyToken(token, secret);
+    }
 }
 else {
     var data = '';


### PR DESCRIPTION
I really like this tool!

I want to be able to use it to verify jwts too though. I'm proposing the simplest solution, which is adding the secret as an optional second argument. When it is provided, then a green or red string at the bottom will indicate whether the signature is valid. If not provided, the script works as before.